### PR TITLE
Fix stop tag handling

### DIFF
--- a/custom_components/nextbus/config_flow.py
+++ b/custom_components/nextbus/config_flow.py
@@ -55,8 +55,14 @@ def _get_stop_tags(
     for direction in listify(route_config["directions"]):
         if not direction["useForUi"]:
             continue
-        for stop in direction["stops"]:
-            stop_directions[stop] = direction["name"]
+        for stop in listify(direction["stops"]):
+            if isinstance(stop, dict):
+                stop_id = stop.get("id") or stop.get("tag")
+            else:
+                stop_id = stop
+            if stop_id is None:
+                continue
+            stop_directions[stop_id] = direction["name"]
 
     # Append directions for stops with shared titles
     for stop_id, title in stop_ids.items():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,89 @@
+import sys
+import types
+from pathlib import Path
+
+package = types.ModuleType("nextbus")
+package.__path__ = [
+    str(Path(__file__).resolve().parents[1] / "custom_components" / "nextbus")
+]
+sys.modules["nextbus"] = package
+
+ha_config_entries = types.ModuleType("config_entries")
+
+class DummyConfigFlow:
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+ha_config_entries.ConfigFlow = DummyConfigFlow
+ha_config_entries.ConfigFlowResult = object
+ha_config_entries.ConfigEntry = object
+sys.modules["homeassistant.config_entries"] = ha_config_entries
+
+ha_const = types.ModuleType("const")
+ha_const.CONF_STOP = "stop"
+ha_const.Platform = types.SimpleNamespace(SENSOR="sensor")
+sys.modules["homeassistant.const"] = ha_const
+
+ha_selector = types.ModuleType("selector")
+class Dummy: pass
+ha_selector.SelectOptionDict = Dummy
+ha_selector.SelectSelector = Dummy
+ha_selector.SelectSelectorConfig = Dummy
+ha_selector.SelectSelectorMode = Dummy
+sys.modules["homeassistant.helpers.selector"] = ha_selector
+
+ha_core = types.ModuleType("core")
+ha_core.HomeAssistant = object
+sys.modules["homeassistant.core"] = ha_core
+
+ha_exceptions = types.ModuleType("exceptions")
+ha_exceptions.ConfigEntryNotReady = type("ConfigEntryNotReady", (Exception,), {})
+sys.modules["homeassistant.exceptions"] = ha_exceptions
+
+requests = types.ModuleType("requests")
+class DummySession:
+    def get(self, *args, **kwargs):
+        raise RuntimeError
+requests.Session = DummySession
+requests.HTTPError = Exception
+sys.modules["requests"] = requests
+
+vol = types.ModuleType("voluptuous")
+vol.Schema = type("Schema", (), {})
+vol.Required = lambda x: x
+vol.Optional = lambda x, default=None: x
+sys.modules["voluptuous"] = vol
+
+from nextbus.config_flow import _get_stop_tags
+
+
+class DummyClient:
+    def route_details(self, route_tag, agency_tag):
+        return {
+            "stops": [
+                {"id": "s1", "name": "Main St"},
+                {"id": "s2", "name": "Main St"},
+                {"id": "s3", "name": "Third St"},
+            ],
+            "directions": [
+                {
+                    "name": "North",
+                    "useForUi": True,
+                    "stops": [{"id": "s1"}, {"id": "s2"}],
+                },
+                {
+                    "name": "South",
+                    "useForUi": True,
+                    "stops": [{"id": "s3"}],
+                },
+            ],
+        }
+
+
+def test_get_stop_tags_handles_dict_stop_entries():
+    tags = _get_stop_tags(DummyClient(), "agency", "route")
+    assert tags == {
+        "s1": "Main St (North)",
+        "s2": "Main St (North)",
+        "s3": "Third St",
+    }


### PR DESCRIPTION
## Summary
- handle dict stop entries when resolving NextBus stop tags
- test stop tag selection with duplicate stop names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68995c8c103c83229d5cde574678c541