### PR TITLE
Prefer stopId for NextBus stops

### DIFF
--- a/custom_components/nextbus/coordinator.py
+++ b/custom_components/nextbus/coordinator.py
@@ -69,10 +69,10 @@ class NextBusDataUpdateCoordinator(
                     stop.get("stopId"),
                 ):
                     stop_id = (
-                        stop.get("id")
-                        or stop.get("stopId")
-                        or stop.get("tag")
+                        stop.get("stopId")
                         or stop.get("code")
+                        or stop.get("id")
+                        or stop.get("tag")
                         or input_stop
                     )
                     break

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -61,20 +61,20 @@ class DummyClient:
     def route_details(self, route_tag, agency_tag):
         return {
             "stops": [
-                {"id": "s1", "name": "Main St"},
-                {"id": "s2", "name": "Main St"},
-                {"id": "s3", "name": "Third St"},
+                {"id": "t1", "stopId": "s1", "name": "Main St"},
+                {"id": "t2", "stopId": "s2", "name": "Main St"},
+                {"id": "t3", "stopId": "s3", "name": "Third St"},
             ],
             "directions": [
                 {
                     "name": "North",
                     "useForUi": True,
-                    "stops": [{"id": "s1"}, {"id": "s2"}],
+                    "stops": [{"id": "t1"}, {"id": "t2"}],
                 },
                 {
                     "name": "South",
                     "useForUi": True,
-                    "stops": [{"id": "s3"}],
+                    "stops": [{"id": "t3"}],
                 },
             ],
         }


### PR DESCRIPTION
## Summary
- Ensure config flow uses numeric stopId for stop selection
- Prefer stopId when resolving API stop identifiers
- Update tests for stopId usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689963a654548322ae3db0729408f1c0