### PR TITLE
Add setup script and Codex config

### DIFF
--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,2 @@
+setup:
+  - ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# setup.sh — initialize a Python venv for NextBus HACS development
+
+set -euo pipefail
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+python -m pip install --upgrade pip setuptools wheel
+pip install requests pytest flake8 black
+
+echo
+
+echo "Environment ready. Run tests with:"
+echo "  source .venv/bin/activate && pytest"


### PR DESCRIPTION
## Summary
- add setup script to bootstrap a Python venv with dependencies
- configure Codex to run the setup script automatically

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689963f0296083229a8d0c0b783c5431